### PR TITLE
Bump postgres odbc version to 16.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ required for your project.
 | Database                                                                                                     | Version    | Linux x86_64 | Linux arm64 | OS X x86_64 | OS X aarch64 |
 | ------------------------------------------------------------------------------------------------------------ | :--------: | :----------: | :---------: | :---------: | :----------: |
 | [Db2](https://early-access.ibm.com/software/support/trial/cst/programwebsite.wss?siteId=853&h=null&tabId=)   | v12.1.0    | `[x]`        | `[ ]`       | `[ ]`       | `[x]`        |
-| [Postgres](https://www.postgresql.org/download)                                                              | 15.00.0000 | `[x]`        | `[x]`       | `[x]`       | `[x]`        |
+| [Postgres](https://www.postgresql.org/download)                                                              | 16.00.0000 | `[x]`        | `[x]`       | `[x]`       | `[x]`        |
 | [MariaDB](https://mariadb.com/kb/en/mariadb-connector-odbc)                                                  | 3.1.9      | `[x]`        | `[x]`       | `[x]`       | `[x]`        |
 
 ## Authors

--- a/packages/postgres.nix
+++ b/packages/postgres.nix
@@ -4,8 +4,8 @@
 }: let
   defaultArgs = {
     pname = "postgres-odbc-driver";
-    version = "15.00.0000";
-    sha256 = "1v7qndj3gqpr2mil8hrgr9as3rdb0z0vyyz1zas7zsijjlsdcmya";
+    version = "16.00.0000";
+    sha256 = "sha256-r9iS+J0uzujT87IxTxvVvy0CIBhyxuNDHlwxCW7KTIs=";
   };
   args = defaultArgs // specialArgs;
 in
@@ -13,7 +13,7 @@ in
     pname = args.pname;
     version = args.version;
     src = pkgs.fetchurl {
-      url = "https://ftp.postgresql.org/pub/odbc/versions/src/psqlodbc-${args.version}.tar.gz";
+      url = "https://ftp.postgresql.org/pub/odbc/versions.old/src/psqlodbc-${args.version}.tar.gz";
       sha256 = args.sha256;
     };
 


### PR DESCRIPTION
Was running into errors compiling the driver on OSX which have been resolved in later versions.

Need to also bump the mirror url b/c they seem to have moved the mirror locations.